### PR TITLE
Small fix to in `create_chat`'s docstring

### DIFF
--- a/src/OpenAI.jl
+++ b/src/OpenAI.jl
@@ -236,7 +236,8 @@ Create chat
 - `temperature::Float64=1.0`: What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. We generally recommend altering this or top_p but not both.
 - `top_p::Float64=1.0`: An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both.
 
-!!! note: do not use `stream=true` option here, instead use the `streamcallback` keyword argument (see the relevant section below).
+!!! note
+    Do not use `stream=true` option here, instead use the `streamcallback` keyword argument (see the relevant section below).
 
 For more details about the endpoint and additional arguments, visit https://platform.openai.com/docs/api-reference/chat
 


### PR DESCRIPTION
Hello! Thank you for this great project. 

There is a note in `create_chat`'s docstring that it currently not displaying properly due to some missing spaces and indentation:

![image](https://github.com/JuliaML/OpenAI.jl/assets/80299581/6992fda3-2109-45b7-b7fa-35d63e52a529)

The changes on this PR fix it so that looks like this:

![image](https://github.com/JuliaML/OpenAI.jl/assets/80299581/eadfea09-5f67-450a-aac2-85fa5def7bc6)

