### PR TITLE
tests bug fix + JET quality & type stability check

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.8.4"
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 
 [compat]
@@ -14,7 +15,9 @@ JSON3 = "1.12"
 julia = "1"
 
 [extras]
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["JET", "Pkg", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "0.8.4"
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 
 [compat]

--- a/test/chatcompletion.jl
+++ b/test/chatcompletion.jl
@@ -13,7 +13,7 @@
     r = create_chat(
         ENV["OPENAI_API_KEY"],
         "gpt-3.5-turbo",
-        [Dict("role" => "user", "content" => "Summarize HTTP.jl package in one short sentence.")],
+        [Dict("role" => "user", "content" => "Summarize HTTP.jl package in a short sentence.")],
         http_kwargs=(connect_timeout=10, readtimeout=0)
     )
     println(r.response["choices"][begin]["message"]["content"])

--- a/test/chatcompletion.jl
+++ b/test/chatcompletion.jl
@@ -13,7 +13,7 @@
     r = create_chat(
         ENV["OPENAI_API_KEY"],
         "gpt-3.5-turbo",
-        [Dict("role" => "user", "content" => "Summarize HTTP.jl package in one sentence.")],
+        [Dict("role" => "user", "content" => "Summarize HTTP.jl package in one short sentence.")],
         http_kwargs=(connect_timeout=10, readtimeout=0)
     )
     println(r.response["choices"][begin]["message"]["content"])

--- a/test/chatcompletion.jl
+++ b/test/chatcompletion.jl
@@ -1,0 +1,44 @@
+@testset "chatcompletion" begin
+    r = create_chat(
+        ENV["OPENAI_API_KEY"],
+        "gpt-3.5-turbo",
+        [Dict("role" => "user", "content" => "What is the OpenAI mission?")]
+    )
+    println(r.response["choices"][begin]["message"]["content"])
+    if !=(r.status, 200)
+        @test false
+    end
+
+    # with http kwargs (with default values)
+    r = create_chat(
+        ENV["OPENAI_API_KEY"],
+        "gpt-3.5-turbo",
+        [Dict("role" => "user", "content" => "Summarize HTTP.jl package in one sentence.")],
+        http_kwargs=(connect_timeout=10, readtimeout=0)
+    )
+    println(r.response["choices"][begin]["message"]["content"])
+    if !=(r.status, 200)
+        @test false
+    end
+end
+
+@testset "chatcompletion - streaming" begin
+
+    r = create_chat(
+        ENV["OPENAI_API_KEY"],
+        "gpt-3.5-turbo",
+        [Dict("role" => "user", "content" => "What continent is New York in? Two word answer.")],
+        streamcallback=let
+            count = 0
+
+            function f(s::String)
+                count = count + 1
+                println("Chunk $count")
+            end
+        end)
+
+    println(map(r -> r["choices"][1]["delta"], r.response))
+    if !=(r.status, 200)
+        @test false
+    end
+end

--- a/test/completion.jl
+++ b/test/completion.jl
@@ -2,57 +2,16 @@
   r = list_models(ENV["OPENAI_API_KEY"])
   if !=(r.status, 200)
     @test false
-  end
+  end  
   r = create_completion(
     ENV["OPENAI_API_KEY"],
-    r.response["data"][begin]["id"];
+    "text-ada-001";
     prompt="Say \"this is a test\""
   )
   println(r.response["choices"][begin]["text"])
   if !=(r.status, 200)
     @test false
-  end
-
-  r = create_chat(
-    ENV["OPENAI_API_KEY"],
-    "gpt-3.5-turbo",
-    [Dict("role" => "user", "content" => "What is the OpenAI mission?")]
-  )
-  println(r.response["choices"][begin]["message"]["content"])
-  if !=(r.status, 200)
-    @test false
-  end
-
-  # with http kwargs (with default values)
-  r = create_chat(
-    ENV["OPENAI_API_KEY"],
-    "gpt-3.5-turbo",
-    [Dict("role" => "user", "content" => "Summarize HTTP.jl package in one sentence.")],
-    http_kwargs=(connect_timeout=10, readtimeout=0)
-  )
-  println(r.response["choices"][begin]["message"]["content"])
-  if !=(r.status, 200)
-    @test false
-  end
-
-  # streaming chat
-  r = create_chat(
-    ENV["OPENAI_API_KEY"],
-    "gpt-3.5-turbo",
-    [Dict("role" => "user", "content" => "What continent is New York in? Two word answer.")],    
-    streamcallback=let
-      count = 0
-
-      function f(s::String)
-        count = count + 1
-        println("Chunk $count")
-      end
-    end)
-
-  println(map(r -> r["choices"][1]["delta"], r.response))
-  if !=(r.status, 200)
-    @test false
-  end
+  end  
 end
 
 @testset "create edit" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,32 @@
 using OpenAI
+using JET
+using Pkg
 using Test
+
+function get_pkg_version(name::AbstractString)
+  for dep in values(Pkg.dependencies())
+      if dep.name == name
+          return dep.version
+      end
+  end
+  return error("Dependency not available")
+end
+
+@testset "Code quality (JET.jl)" begin
+  if VERSION >= v"1.9"
+      @assert get_pkg_version("JET") >= v"0.8.4"
+      JET.test_package(OpenAI; target_defined_modules=true)
+  end
+end
+
 
 @testset "OpenAI.jl" begin
   printstyled(color=:blue, "\n")
   @testset "models" begin
     include("models.jl")
+  end
+  @testset "chatcompletion" begin
+    include("chatcompletion.jl")
   end
   @testset "completion" begin
     include("completion.jl")
@@ -12,7 +34,7 @@ using Test
   @testset "embeddings" begin
     include("embeddings.jl")
   end
-  @testset "user usage" begin
+  @testset "usage" begin
     include("usage.jl")
-  end
+  end  
 end


### PR DESCRIPTION
The `completion` test was broken. The main reason for that was that the model used was retrieved by `r.response["data"][begin]["id"]`, which is not guaranteed always to return a model that is compatible with the `completion` endpoint (these days it returns the `whisper-1` model). The test `completion` test is using `text-ada-001` model now.

Other changes:

- created a separate test file for `chat completion`:  despite the naming similarity, the `/v1/chat/completions` has nothing to do with `/v1/completions`. If a test fails, we need to be able to differentiate between the two easily.
- added [JET](https://aviatesk.github.io/JET.jl/dev/jetanalysis/#JET.test_package) code quality test - this check will work as a helpful additional QA layer