### PR TITLE
fix semicolon in HTTP.request

### DIFF
--- a/src/OpenAI.jl
+++ b/src/OpenAI.jl
@@ -77,7 +77,7 @@ end
 
 function request_body(url, method; input, headers, kwargs...)
     input = input === nothing ? [] : input
-    resp = HTTP.request(method, url, body=input, headers=headers, kwargs...)
+    resp = HTTP.request(method, url; body=input, headers=headers, kwargs...)
     return resp, resp.body
 end
 


### PR DESCRIPTION
At the moment, `http_kwargs` (ie, kwargs to be provided to HTTP.jl requests) are not being passed, because of a missing semicolon inside of `request_body()` call.

You can test this PR by asking for verbosity from HTTP.jl:
```
using Logging

with_logger(ConsoleLogger(stderr, Logging.Debug)) do
    r = create_chat(api_key, model, [Dict("role" => "user", "content" => "say hi.")]; max_tokens=1, http_kwargs=(; verbose=2))
end

# gives nothing on main branch
# this PR would show corresponding logs from HTTP.jl
```


Toy example:
```
function probe(args...; kwargs...)
    @info "Received: " args kwargs
end
function test_no_semicolon(; kwargs...)
    probe("testsetup", a=1, b=2, kwargs...)
end
function test_semicolon(; kwargs...)
    probe("testsetup"; a=1, b=2, kwargs...)
end

# Example how request_body currently works -- c and d end up in the args slot of the function
test_no_semicolon(; c=3, d=4)
┌ Info: Received: 
│   args = ("testsetup", :c => 3, :d => 4)
│   kwargs =
│    pairs(::NamedTuple) with 2 entries:
│      :a => 1
└      :b => 2

# Example when fixed -- c and d are passed downstream as kwargs
┌ Info: Received: 
│   args = ("testsetup",)
│   kwargs =
│    pairs(::NamedTuple) with 4 entries:
│      :a => 1
│      :b => 2
│      :c => 3
└      :d => 4
```