### PR TITLE
Fix assistant tests

### DIFF
--- a/test/assistants.jl
+++ b/test/assistants.jl
@@ -183,6 +183,7 @@ end
     @test new_run.response.id in ids
 
     # modify the run
+    sleep(4) # wait until run is complete
     modded_run = modify_run(api_key,
         thread.response.id,
         new_run.response.id,


### PR DESCRIPTION
The issue reported in #57 seems to basically be due to the test being called too close to the original run call. This PR just adds a `sleep` call to wait four seconds before `modify_run` is called.