### PR TITLE
Increment version number

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OpenAI"
 uuid = "e9f21f70-7185-4079-aca2-91159181367c"
 authors = ["Rory Linehan @rory-linehan", "Marius Fersigan @algunion", "RexWzh @RexWzh", "Thatcher Chamberlin @ThatcherC", "Nicu Stiurca @nstiurca", "Peter @chengchingwen", "Stefan Wojcik @stefanjwojcik", "J S @svilupp", "Logan Kilpatrick @logankilpatrick", "Jerry Ling @Moelf"]
-version = "0.8.7"
+version = "0.9.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
Should probably tag a release to get the assistant features (#57) out. I figured a minor version bump was in order here, so we'd be at 0.9.0.