### PR TITLE
Fix query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fixed a bug in `request_body` that prevented `query` argument from being passed to `HTTP.jl`.
 * Updated completion model in the unit tests suite (`ada` series has been deprecated).
+* Added warnings to `create_edit` that it's deprecated by OpenAI. Disabled tests for `get_usage_status` and `create_edit` functions, as they cannot be tested via API.
 
 ### 0.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 0.9.1
+
+* Fixed a bug in `request_body` that prevented `query` argument from being passed to `HTTP.jl`.
+* Updated completion model in the unit tests suite (`ada` series has been deprecated).
+
+### 0.9.0
+
+* Added OpenAI Assistants API
+
 ### 0.8.7
 
 * disable `test/usage.jl` in `test/runtests.jl` to close issue: https://github.com/JuliaML/OpenAI.jl/issues/46

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OpenAI"
 uuid = "e9f21f70-7185-4079-aca2-91159181367c"
 authors = ["Rory Linehan @rory-linehan", "Marius Fersigan @algunion", "RexWzh @RexWzh", "Thatcher Chamberlin @ThatcherC", "Nicu Stiurca @nstiurca", "Peter @chengchingwen", "Stefan Wojcik @stefanjwojcik", "J S @svilupp", "Logan Kilpatrick @logankilpatrick", "Jerry Ling @Moelf"]
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/OpenAI.jl
+++ b/src/OpenAI.jl
@@ -392,6 +392,8 @@ end
 """
 Create edit
 
+Note: This functionality is not accessible via API anymore -- see https://platform.openai.com/docs/deprecations
+
 # Arguments:
 - `api_key::String`: OpenAI API key
 - `model_id::String`: Model id (e.g. "text-davinci-edit-001")
@@ -409,6 +411,7 @@ function create_edit(api_key::String,
     instruction::String;
     http_kwargs::NamedTuple = NamedTuple(),
     kwargs...)
+    @warn "This functionality is not accessible via API anymore -- see https://platform.openai.com/docs/deprecations"
     return openai_request("edits",
         api_key;
         method = "POST",

--- a/src/OpenAI.jl
+++ b/src/OpenAI.jl
@@ -77,7 +77,6 @@ end
 
 function request_body(url, method; input, headers, query, kwargs...)
     input = isnothing(input) ? [] : input
-    query = isnothing(query) ? [] : query
 
     resp = HTTP.request(method,
         url;

--- a/test/completion.jl
+++ b/test/completion.jl
@@ -4,7 +4,7 @@
         @test false
     end
     r = create_completion(ENV["OPENAI_API_KEY"],
-        "text-ada-001";
+        "gpt-3.5-turbo-instruct";
         prompt = "Say \"this is a test\"")
     println(r.response["choices"][begin]["text"])
     if !=(r.status, 200)
@@ -14,7 +14,7 @@ end
 
 @testset "create edit" begin
     r = create_edit(ENV["OPENAI_API_KEY"],
-        "text-davinci-edit-001",
+        "gpt-3.5-turbo-instruct",
         "Fix this piece of text for grammatical errors",
         input = "I hav ben riting sence i wuz 5")
     println(r.response["choices"][begin]["text"])

--- a/test/completion.jl
+++ b/test/completion.jl
@@ -12,13 +12,16 @@
     end
 end
 
-@testset "create edit" begin
-    r = create_edit(ENV["OPENAI_API_KEY"],
-        "gpt-3.5-turbo-instruct",
-        "Fix this piece of text for grammatical errors",
-        input = "I hav ben riting sence i wuz 5")
-    println(r.response["choices"][begin]["text"])
-    if !=(r.status, 200)
-        @test false
+# This functionality is not accessible via API anymore -- see https://platform.openai.com/docs/deprecations
+@test_skip begin
+    @testset "create edit" begin
+        r = create_edit(ENV["OPENAI_API_KEY"],
+            "gpt-3.5-turbo-instruct",
+            "Fix this piece of text for grammatical errors",
+            input = "I hav ben riting sence i wuz 5")
+        println(r.response["choices"][begin]["text"])
+        if !=(r.status, 200)
+            @test false
+        end
     end
 end

--- a/test/usage.jl
+++ b/test/usage.jl
@@ -1,14 +1,17 @@
 # Get usage status of an api
 
 # See https://github.com/JuliaML/OpenAI.jl/issues/46
-@testset "usage information" begin
-    provider = OpenAI.OpenAIProvider(ENV["OPENAI_API_KEY"], "https://api.openai.com/v1", "")
-    (; quota, usage, daily_costs) = get_usage_status(provider, numofdays = 5)
-    @test quota > 0
-    @test usage >= 0
-    @test length(daily_costs) == 5
-    println("Total quota: $quota")
-    println("Total usage: $usage")
-    costs = [sum(item["cost"] for item in day.line_items) for day in daily_costs]
-    println("Recent costs(5 days): $costs")
+# This functionality is not accessible via API anymore -- see https://platform.openai.com/docs/api-reference/administration
+@test_skip begin
+    @testset "usage information" begin
+        provider = OpenAI.OpenAIProvider(ENV["OPENAI_API_KEY"], "https://api.openai.com/v1", "")
+        (; quota, usage, daily_costs) = get_usage_status(provider, numofdays = 5)
+        @test quota > 0
+        @test usage >= 0
+        @test length(daily_costs) == 5
+        println("Total quota: $quota")
+        println("Total usage: $usage")
+        costs = [sum(item["cost"] for item in day.line_items) for day in daily_costs]
+        println("Recent costs(5 days): $costs")
+    end
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaML/OpenAI.jl/issues/63

* Fixed a bug in `request_body` that prevented `query` argument from being passed to `HTTP.jl`.
* Updated completion model in the unit tests suite (`ada` series has been deprecated).
* Added warnings to `create_edit` that it's deprecated by OpenAI. Disabled tests for `get_usage_status` and `create_edit` functions, as they cannot be tested via API.


Note the tests would fail on `create_edit` and `get_usage_status`, both are NOT supported anymore and need to be removed in the next minor release.