### PR TITLE
Integrate StreamCallbacks.jl for streaming

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,17 +7,20 @@ version = "0.11.0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+StreamCallbacks = "c1b9e933-98a0-46fc-8ea7-3b58b195fb0a"
 
 [compat]
 Dates = "1"
 HTTP = "1"
 JSON3 = "1"
+StreamCallbacks = "0.6"
 julia = "1"
 
 [extras]
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [targets]
-test = ["JET", "Pkg", "Test"]
+test = ["JET", "Pkg", "Test", "Sockets"]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,55 @@ response = create_chat(
 
 For more use cases [see tests](https://github.com/JuliaML/OpenAI.jl/tree/main/test).
 
+## Streaming with StreamCallbacks
+
+OpenAI.jl integrates [StreamCallbacks.jl](https://github.com/svilupp/StreamCallbacks.jl) for
+streaming responses.
+
+### 1. Stream to any `IO`
+
+```julia
+create_chat(secret_key, model, messages; streamcallback=stdout)
+```
+
+### 2. Capture stream chunks
+
+```julia
+using StreamCallbacks
+cb = StreamCallback()
+create_chat(secret_key, model, messages; streamcallback=cb)
+cb.chunks
+```
+
+### 3. Customize printing
+
+```julia
+using StreamCallbacks
+import StreamCallbacks: print_content
+
+function print_content(io::IO, content; kwargs...)
+    printstyled(io, "🌊 $content"; color=:cyan)
+end
+
+cb = StreamCallback()
+create_chat(secret_key, model, messages; streamcallback=cb)
+```
+
+To fully customize processing, you can overload `StreamCallbacks.callback`:
+
+```julia
+using StreamCallbacks: callback, AbstractStreamCallback, AbstractStreamChunk, extract_content, print_content
+
+@inline function callback(cb::AbstractStreamCallback, chunk::AbstractStreamChunk; kwargs...)
+    processed_text = extract_content(cb.flavor, chunk; kwargs...)
+    isnothing(processed_text) && return nothing
+    print_content(cb.out, processed_text; kwargs...)
+    return nothing
+end
+```
+
+See [`examples/streamcallbacks.jl`](examples/streamcallbacks.jl) for a full walkthrough.
+
 ## Feature requests
 
 Feel free to open a PR, or file an issue if that's out of reach!

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ __⚠️ We strongly suggest setting up your API key as an ENV variable__.
 
 ```julia
 secret_key = ENV["OPENAI_API_KEY"]
-model = "gpt-4o-mini"
+model = "gpt-5-mini"
 prompt =  "Say \"this is a test\""
 
 r = create_chat(
@@ -57,7 +57,7 @@ provider = OpenAI.OpenAIProvider(
 )
 response = create_chat(
     provider,
-    "gpt-4o-mini",
+    "gpt-5-mini",
     [Dict("role" => "user", "content" => "Write some ancient Greek poetry")]
 )
 ```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ create_chat(secret_key, model, messages; streamcallback=stdout)
 ### 2. Capture stream chunks
 
 ```julia
-using StreamCallbacks
+using OpenAI
 cb = StreamCallback()
 create_chat(secret_key, model, messages; streamcallback=cb)
 cb.chunks
@@ -87,7 +87,7 @@ cb.chunks
 ### 3. Customize printing
 
 ```julia
-using StreamCallbacks
+using OpenAI
 import StreamCallbacks: print_content
 
 function print_content(io::IO, content; kwargs...)
@@ -101,7 +101,8 @@ create_chat(secret_key, model, messages; streamcallback=cb)
 To fully customize processing, you can overload `StreamCallbacks.callback`:
 
 ```julia
-using StreamCallbacks: callback, AbstractStreamCallback, AbstractStreamChunk, extract_content, print_content
+using OpenAI
+import StreamCallbacks: callback, AbstractStreamCallback, AbstractStreamChunk, extract_content, print_content
 
 @inline function callback(cb::AbstractStreamCallback, chunk::AbstractStreamChunk; kwargs...)
     processed_text = extract_content(cb.flavor, chunk; kwargs...)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,3 +23,7 @@ create_embeddings(api_key::String, input, model_id::String=DEFAULT_EMBEDDING_MOD
 ```@docs
 create_images(api_key::String, prompt, n::Integer=1, size::String="256x256"; http_kwargs::NamedTuple=NamedTuple(), kwargs...)
 ```
+
+## Streaming
+
+See [Streaming](streaming.md) for examples using StreamCallbacks.

--- a/docs/src/streaming.md
+++ b/docs/src/streaming.md
@@ -9,7 +9,7 @@ create_chat(secret_key, model, messages; streamcallback=stdout)
 
 ## 2. Capture stream chunks
 ```julia
-using StreamCallbacks
+using OpenAI
 cb = StreamCallback()
 create_chat(secret_key, model, messages; streamcallback=cb)
 cb.chunks
@@ -17,7 +17,7 @@ cb.chunks
 
 ## 3. Customize printing
 ```julia
-using StreamCallbacks
+using OpenAI
 import StreamCallbacks: print_content
 
 function print_content(io::IO, content; kwargs...)
@@ -30,7 +30,8 @@ create_chat(secret_key, model, messages; streamcallback=cb)
 
 For complete control you can overload `StreamCallbacks.callback`:
 ```julia
-using StreamCallbacks: callback, AbstractStreamCallback, AbstractStreamChunk, extract_content, print_content
+using OpenAI
+import StreamCallbacks: callback, AbstractStreamCallback, AbstractStreamChunk, extract_content, print_content
 
 @inline function callback(cb::AbstractStreamCallback, chunk::AbstractStreamChunk; kwargs...)
     processed_text = extract_content(cb.flavor, chunk; kwargs...)

--- a/docs/src/streaming.md
+++ b/docs/src/streaming.md
@@ -1,0 +1,43 @@
+# Streaming
+
+OpenAI.jl integrates [StreamCallbacks.jl](https://github.com/svilupp/StreamCallbacks.jl) for streaming responses.
+
+## 1. Stream to any `IO`
+```julia
+create_chat(secret_key, model, messages; streamcallback=stdout)
+```
+
+## 2. Capture stream chunks
+```julia
+using StreamCallbacks
+cb = StreamCallback()
+create_chat(secret_key, model, messages; streamcallback=cb)
+cb.chunks
+```
+
+## 3. Customize printing
+```julia
+using StreamCallbacks
+import StreamCallbacks: print_content
+
+function print_content(io::IO, content; kwargs...)
+    printstyled(io, "🌊 $content"; color=:cyan)
+end
+
+cb = StreamCallback()
+create_chat(secret_key, model, messages; streamcallback=cb)
+```
+
+For complete control you can overload `StreamCallbacks.callback`:
+```julia
+using StreamCallbacks: callback, AbstractStreamCallback, AbstractStreamChunk, extract_content, print_content
+
+@inline function callback(cb::AbstractStreamCallback, chunk::AbstractStreamChunk; kwargs...)
+    processed_text = extract_content(cb.flavor, chunk; kwargs...)
+    isnothing(processed_text) && return nothing
+    print_content(cb.out, processed_text; kwargs...)
+    return nothing
+end
+```
+
+See the `examples/streamcallbacks.jl` script for a full walkthrough.

--- a/examples/functions_example.jl
+++ b/examples/functions_example.jl
@@ -1,24 +1,24 @@
 ## Example of using Functions for Julia 
 
-
 ## Functions 
 tools = [
     Dict(
-        "type" => "function",
-        "name" => "get_avg_temperature",
-        "description" => "Get average temperature in a given location",
-        "parameters" => Dict(
+    "type" => "function",
+    "name" => "get_avg_temperature",
+    "description" => "Get average temperature in a given location",
+    "parameters" => Dict(
         "type" => "object",
         "properties" => Dict(
             "location" => Dict(
-                "type" => "string",
-                "description" => "The city with no spaces, e.g. SanFrancisco",
-            )
-        ),
-        "required" => ["location"],
+            "type" => "string",
+            "description" => "The city with no spaces, e.g. SanFrancisco"
         )
+        ),
+        "required" => ["location"]
     )
+)
 ]
-resp = create_responses(ENV["OPENAI_API_KEY"], "What is the avg temp in New York?"; tools=tools, tool_choice="auto")
+resp = create_responses(ENV["OPENAI_API_KEY"], "What is the avg temp in New York?";
+    tools = tools, tool_choice = "auto")
 
 resp.response.output

--- a/examples/streamcallbacks.jl
+++ b/examples/streamcallbacks.jl
@@ -6,23 +6,24 @@ model = "gpt-4o-mini"
 messages = [Dict("role" => "user", "content" => "Write a short haiku about streams.")]
 
 # 1. Stream to stdout (no differences)
-create_chat(api_key, model, messages; streamcallback=stdout)
+create_chat(api_key, model, messages; streamcallback = stdout)
 
 # 2. Stream with explicit StreamCallback to capture chunks
 cb = StreamCallback()
-create_chat(api_key, model, messages; streamcallback=cb)
+create_chat(api_key, model, messages; streamcallback = cb)
 @info "Received $(length(cb.chunks)) chunks"
 
 # 3. Customize printing via `print_content`
 import StreamCallbacks: print_content
 function print_content(io::IO, content; kwargs...)
-    printstyled(io, "🌊 $content"; color=:cyan)
+    printstyled(io, "🌊 $content"; color = :cyan)
 end
 cb2 = StreamCallback()
-create_chat(api_key, model, messages; streamcallback=cb2)
+create_chat(api_key, model, messages; streamcallback = cb2)
 
 # 4. Overload `callback` to change chunk handling
-import StreamCallbacks: callback, AbstractStreamCallback, AbstractStreamChunk, extract_content
+import StreamCallbacks: callback, AbstractStreamCallback, AbstractStreamChunk,
+                        extract_content
 @inline function callback(cb::AbstractStreamCallback, chunk::AbstractStreamChunk; kwargs...)
     processed_text = extract_content(cb.flavor, chunk; kwargs...)
     isnothing(processed_text) && return nothing
@@ -30,4 +31,4 @@ import StreamCallbacks: callback, AbstractStreamCallback, AbstractStreamChunk, e
     return nothing
 end
 cb3 = StreamCallback()
-create_chat(api_key, model, messages; streamcallback=cb3)
+create_chat(api_key, model, messages; streamcallback = cb3)

--- a/examples/streamcallbacks.jl
+++ b/examples/streamcallbacks.jl
@@ -1,5 +1,5 @@
 # Streaming examples using StreamCallbacks.jl
-using OpenAI, StreamCallbacks
+using OpenAI
 
 api_key = get(ENV, "OPENAI_API_KEY", "")
 model = "gpt-4o-mini"

--- a/examples/streamcallbacks.jl
+++ b/examples/streamcallbacks.jl
@@ -2,7 +2,7 @@
 using OpenAI
 
 api_key = get(ENV, "OPENAI_API_KEY", "")
-model = "gpt-4o-mini"
+model = "gpt-5-mini"
 messages = [Dict("role" => "user", "content" => "Write a short haiku about streams.")]
 
 # 1. Stream to stdout (no differences)

--- a/examples/streamcallbacks.jl
+++ b/examples/streamcallbacks.jl
@@ -1,0 +1,33 @@
+# Streaming examples using StreamCallbacks.jl
+using OpenAI, StreamCallbacks
+
+api_key = get(ENV, "OPENAI_API_KEY", "")
+model = "gpt-4o-mini"
+messages = [Dict("role" => "user", "content" => "Write a short haiku about streams.")]
+
+# 1. Stream to stdout (no differences)
+create_chat(api_key, model, messages; streamcallback=stdout)
+
+# 2. Stream with explicit StreamCallback to capture chunks
+cb = StreamCallback()
+create_chat(api_key, model, messages; streamcallback=cb)
+@info "Received $(length(cb.chunks)) chunks"
+
+# 3. Customize printing via `print_content`
+import StreamCallbacks: print_content
+function print_content(io::IO, content; kwargs...)
+    printstyled(io, "🌊 $content"; color=:cyan)
+end
+cb2 = StreamCallback()
+create_chat(api_key, model, messages; streamcallback=cb2)
+
+# 4. Overload `callback` to change chunk handling
+import StreamCallbacks: callback, AbstractStreamCallback, AbstractStreamChunk, extract_content
+@inline function callback(cb::AbstractStreamCallback, chunk::AbstractStreamChunk; kwargs...)
+    processed_text = extract_content(cb.flavor, chunk; kwargs...)
+    isnothing(processed_text) && return nothing
+    print_content(cb.out, reverse(processed_text); kwargs...)
+    return nothing
+end
+cb3 = StreamCallback()
+create_chat(api_key, model, messages; streamcallback=cb3)

--- a/src/OpenAI.jl
+++ b/src/OpenAI.jl
@@ -50,14 +50,14 @@ function auth_header(::OpenAIProvider, api_key::AbstractString)
     isempty(api_key) && throw(ArgumentError("api_key cannot be empty"))
     [
         "Authorization" => "Bearer $api_key",
-        "Content-Type" => "application/json",
+        "Content-Type" => "application/json"
     ]
 end
 function auth_header(::AzureProvider, api_key::AbstractString)
     isempty(api_key) && throw(ArgumentError("api_key cannot be empty"))
     [
         "api-key" => api_key,
-        "Content-Type" => "application/json",
+        "Content-Type" => "application/json"
     ]
 end
 
@@ -108,14 +108,14 @@ function status_error(resp, log = nothing)
 end
 
 function _request(api::AbstractString,
-    provider::AbstractOpenAIProvider,
-    api_key::AbstractString = provider.api_key;
-    method,
-    query = nothing,
-    http_kwargs,
-    streamcallback = nothing,
-    additional_headers::AbstractVector = Pair{String, String}[],
-    kwargs...)
+        provider::AbstractOpenAIProvider,
+        api_key::AbstractString = provider.api_key;
+        method,
+        query = nothing,
+        http_kwargs,
+        streamcallback = nothing,
+        additional_headers::AbstractVector = Pair{String, String}[],
+        kwargs...)
     cb = nothing
     if !isnothing(streamcallback)
         cb, kwargs = configure_callback!(streamcallback; kwargs...)
@@ -126,14 +126,16 @@ function _request(api::AbstractString,
     headers = vcat(auth_header(provider, api_key), additional_headers)
 
     if isnothing(cb)
-        resp, body = request_body(url,
+        resp,
+        body = request_body(url,
             method;
             input = params,
             headers = headers,
             query = query,
             http_kwargs...)
     else
-        resp, body = request_body_live(url;
+        resp,
+        body = request_body_live(url;
             method,
             input = params,
             headers = headers,
@@ -149,11 +151,11 @@ function _request(api::AbstractString,
 end
 
 function openai_request(api::AbstractString,
-    api_key::AbstractString;
-    method,
-    http_kwargs,
-    streamcallback = nothing,
-    kwargs...)
+        api_key::AbstractString;
+        method,
+        http_kwargs,
+        streamcallback = nothing,
+        kwargs...)
     global DEFAULT_PROVIDER
     _request(api,
         DEFAULT_PROVIDER,
@@ -165,11 +167,11 @@ function openai_request(api::AbstractString,
 end
 
 function openai_request(api::AbstractString,
-    provider::AbstractOpenAIProvider;
-    method,
-    http_kwargs,
-    streamcallback = nothing,
-    kwargs...)
+        provider::AbstractOpenAIProvider;
+        method,
+        http_kwargs,
+        streamcallback = nothing,
+        kwargs...)
     _request(api, provider; method, http_kwargs, streamcallback = streamcallback, kwargs...)
 end
 
@@ -182,7 +184,8 @@ Streaming-related keyword arguments are added to `kwargs`.
 Returns the configured callback and updated keyword arguments.
 """
 function configure_callback!(streamcallback; kwargs...)
-    cb = streamcallback isa StreamCallback ? streamcallback : StreamCallback(out = streamcallback)
+    cb = streamcallback isa StreamCallback ? streamcallback :
+         StreamCallback(out = streamcallback)
     isnothing(cb.flavor) && (cb.flavor = OpenAIStream())
     new_kwargs = (; kwargs..., stream = true, stream_options = (; include_usage = true))
     return cb, new_kwargs
@@ -221,8 +224,8 @@ Retrieve model
 For additional details, visit <https://platform.openai.com/docs/api-reference/models/retrieve>
 """
 function retrieve_model(api_key::String,
-    model_id::String;
-    http_kwargs::NamedTuple = NamedTuple())
+        model_id::String;
+        http_kwargs::NamedTuple = NamedTuple())
     return openai_request("models/$(model_id)",
         api_key;
         method = "GET",
@@ -246,9 +249,9 @@ For more details about the endpoint and additional arguments, visit <https://pla
 - `http_kwargs::NamedTuple=NamedTuple()`: Keyword arguments to pass to HTTP.request (e. g., `http_kwargs=(connection_timeout=2,)` to set a connection timeout of 2 seconds).
 """
 function create_completion(api_key::String,
-    model_id::String;
-    http_kwargs::NamedTuple = NamedTuple(),
-    kwargs...)
+        model_id::String;
+        http_kwargs::NamedTuple = NamedTuple(),
+        kwargs...)
     return openai_request("completions",
         api_key;
         method = "POST",
@@ -328,11 +331,11 @@ julia> map(r->r["choices"][1]["delta"], CC.response)
 ```
 """
 function create_chat(api_key::String,
-    model_id::String,
-    messages;
-    http_kwargs::NamedTuple = NamedTuple(),
-    streamcallback = nothing,
-    kwargs...)
+        model_id::String,
+        messages;
+        http_kwargs::NamedTuple = NamedTuple(),
+        streamcallback = nothing,
+        kwargs...)
     return openai_request("chat/completions",
         api_key;
         method = "POST",
@@ -343,11 +346,11 @@ function create_chat(api_key::String,
         kwargs...)
 end
 function create_chat(provider::AbstractOpenAIProvider,
-    model_id::String,
-    messages;
-    http_kwargs::NamedTuple = NamedTuple(),
-    streamcallback = nothing,
-    kwargs...)
+        model_id::String,
+        messages;
+        http_kwargs::NamedTuple = NamedTuple(),
+        streamcallback = nothing,
+        kwargs...)
     return openai_request("chat/completions",
         provider;
         method = "POST",
@@ -366,12 +369,12 @@ Convenience overload for testing/debugging that forwards to `create_chat` with
 support for `StreamCallback` objects.
 """
 function create_chat(schema,
-    api_key::AbstractString,
-    model::AbstractString,
-    conversation;
-    http_kwargs::NamedTuple = NamedTuple(),
-    streamcallback::Any = nothing,
-    kwargs...)
+        api_key::AbstractString,
+        model::AbstractString,
+        conversation;
+        http_kwargs::NamedTuple = NamedTuple(),
+        streamcallback::Any = nothing,
+        kwargs...)
     return create_chat(api_key, model, conversation;
         http_kwargs = http_kwargs,
         streamcallback = streamcallback,
@@ -394,10 +397,10 @@ Create embeddings
         For additional details about the endpoint, visit <https://platform.openai.com/docs/api-reference/embeddings>
         """
 function create_embeddings(api_key::String,
-    input,
-    model_id::String = DEFAULT_EMBEDDING_MODEL_ID;
-    http_kwargs::NamedTuple = NamedTuple(),
-    kwargs...)
+        input,
+        model_id::String = DEFAULT_EMBEDDING_MODEL_ID;
+        http_kwargs::NamedTuple = NamedTuple(),
+        kwargs...)
     return openai_request("embeddings",
         api_key;
         method = "POST",
@@ -407,16 +410,16 @@ function create_embeddings(api_key::String,
         kwargs...)
 end
 function create_embeddings(provider::AbstractOpenAIProvider,
-    input;
-    model_id::String = DEFAULT_EMBEDDING_MODEL_ID,   
-    http_kwargs::NamedTuple=NamedTuple(),
-    streamcallback=nothing,
-    kwargs...)
+        input;
+        model_id::String = DEFAULT_EMBEDDING_MODEL_ID,
+        http_kwargs::NamedTuple = NamedTuple(),
+        streamcallback = nothing,
+        kwargs...)
     return OpenAI.openai_request("embeddings",
         provider;
-        method="POST",
-        http_kwargs=http_kwargs,
-        model=model_id,
+        method = "POST",
+        http_kwargs = http_kwargs,
+        model = model_id,
         input,
         kwargs...)
 end
@@ -440,11 +443,11 @@ download like this:
 `download(r.response["data"][begin]["url"], "image.png")`
 """
 function create_images(api_key::String,
-    prompt,
-    n::Integer = 1,
-    size::String = "256x256";
-    http_kwargs::NamedTuple = NamedTuple(),
-    kwargs...)
+        prompt,
+        n::Integer = 1,
+        size::String = "256x256";
+        http_kwargs::NamedTuple = NamedTuple(),
+        kwargs...)
     return openai_request("images/generations",
         api_key;
         method = "POST",
@@ -454,7 +457,6 @@ function create_images(api_key::String,
 end
 
 include("assistants.jl")
-
 
 """
 Create responses
@@ -521,14 +523,15 @@ response = create_responses(api_key, "How much wood would a woodchuck chuck?";
 ```
 
 """
-function create_responses(api_key::String, input, model="gpt-4o-mini"; http_kwargs::NamedTuple = NamedTuple(), kwargs...)
-    return openai_request("responses", 
-                            api_key; 
-                            method = "POST", 
-                            input = input, 
-                            model=model, 
-                            http_kwargs = http_kwargs,
-                            kwargs...)
+function create_responses(api_key::String, input, model = "gpt-4o-mini";
+        http_kwargs::NamedTuple = NamedTuple(), kwargs...)
+    return openai_request("responses",
+        api_key;
+        method = "POST",
+        input = input,
+        model = model,
+        http_kwargs = http_kwargs,
+        kwargs...)
 end
 
 export OpenAIResponse

--- a/src/OpenAI.jl
+++ b/src/OpenAI.jl
@@ -284,7 +284,7 @@ For more details about the endpoint and additional arguments, visit <https://pla
 ## Example:
 
 ```julia
-julia> CC = create_chat("..........", "gpt-4o-mini", 
+julia> CC = create_chat("..........", "gpt-5-mini", 
     [Dict("role" => "user", "content"=> "What is the OpenAI mission?")]
 );
 
@@ -302,7 +302,7 @@ The response body will reflect the chunked nature of the response, so some reass
 message returned by the API.
 
 ```julia
-julia> CC = create_chat(key, "gpt-4o-mini",
+julia> CC = create_chat(key, "gpt-5-mini",
            [Dict("role" => "user", "content"=> "What continent is New York in? Two word answer.")],
        streamcallback = x->println(Dates.now()));
        2023-03-27T12:34:50.428
@@ -468,7 +468,7 @@ https://platform.openai.com/docs/api-reference/responses/create
 - `input`: The input text to generate the response(s) for, as String or Dict.
     To get responses for multiple inputs in a single request, pass an array of strings
     or array of token arrays. Each input must not exceed 8192 tokens in length.
-- `model::String`: Model id. Defaults to "gpt-4o-mini".
+- `model::String`: Model id. Defaults to "gpt-5-mini".
 - `kwargs...`: Additional arguments to pass to the API.
     - `tools::Int`: The number of responses to generate for the input. Defaults to 1.
 
@@ -523,7 +523,7 @@ response = create_responses(api_key, "How much wood would a woodchuck chuck?";
 ```
 
 """
-function create_responses(api_key::String, input, model = "gpt-4o-mini";
+function create_responses(api_key::String, input, model = "gpt-5-mini";
         http_kwargs::NamedTuple = NamedTuple(), kwargs...)
     return openai_request("responses",
         api_key;

--- a/src/assistants.jl
+++ b/src/assistants.jl
@@ -63,14 +63,14 @@ Main.OpenAI.OpenAIResponse{JSON3.Object{Vector{UInt8}, Vector{UInt64}}}(200, {
 """
 
 function create_assistant(api_key::String,
-    model_id::String;
-    name::String = "",
-    description::String = "",
-    instructions::String = "",
-    tools::Vector = [],
-    file_ids::Vector = [],
-    metadata::Dict = Dict(),
-    http_kwargs::NamedTuple = NamedTuple())
+        model_id::String;
+        name::String = "",
+        description::String = "",
+        instructions::String = "",
+        tools::Vector = [],
+        file_ids::Vector = [],
+        metadata::Dict = Dict(),
+        http_kwargs::NamedTuple = NamedTuple())
     # The API endpoint is
     # POST https://api.openai.com/v1/assistants
     # Requires the OpenAI-Beta: assistants=v1 header
@@ -133,8 +133,8 @@ Main.OpenAI.OpenAIResponse{JSON3.Object{Vector{UInt8}, Vector{UInt64}}}(200, {
 ```
 """
 function get_assistant(api_key::String,
-    assistant_id::String;
-    http_kwargs::NamedTuple = NamedTuple())
+        assistant_id::String;
+        http_kwargs::NamedTuple = NamedTuple())
     # The API endpoint is
     # GET https://api.openai.com/v1/assistants/:assistant_id
     # Requires the OpenAI-Beta: assistants=v1 header
@@ -212,18 +212,18 @@ Main.OpenAI.OpenAIResponse{JSON3.Object{Vector{UInt8}, Vector{UInt64}}}(200, {
 ```
 """
 function list_assistants(api_key::AbstractString;
-    limit::Union{Integer, AbstractString} = 20,
-    order::AbstractString = "desc",
-    after::AbstractString = "",
-    before::AbstractString = "",
-    http_kwargs::NamedTuple = NamedTuple())
+        limit::Union{Integer, AbstractString} = 20,
+        order::AbstractString = "desc",
+        after::AbstractString = "",
+        before::AbstractString = "",
+        http_kwargs::NamedTuple = NamedTuple())
     # The API endpoint is
     # GET https://api.openai.com/v1/assistants
     # Requires the OpenAI-Beta: assistants=v1 header
 
     # Build query parameters
     query = Pair{String, String}["limit" => string(limit),
-        "order" => order]
+    "order" => order]
     length(after) > 0 && push!(query, "after" => after)
     length(before) > 0 && push!(query, "before" => before)
 
@@ -296,15 +296,15 @@ Main.OpenAI.OpenAIResponse{JSON3.Object{Vector{UInt8}, Vector{UInt64}}}(200, {
 ```
 """
 function modify_assistant(api_key::AbstractString,
-    assistant_id::AbstractString;
-    model = nothing,
-    name = nothing,
-    description = nothing,
-    instructions = nothing,
-    tools = nothing,
-    file_ids = nothing,
-    metadata = nothing,
-    http_kwargs::NamedTuple = NamedTuple())
+        assistant_id::AbstractString;
+        model = nothing,
+        name = nothing,
+        description = nothing,
+        instructions = nothing,
+        tools = nothing,
+        file_ids = nothing,
+        metadata = nothing,
+        http_kwargs::NamedTuple = NamedTuple())
     # The API endpoint is
     # PATCH https://api.openai.com/v1/assistants/:assistant_id
     # Requires the OpenAI-Beta: assistants=v1 header
@@ -379,8 +379,8 @@ Main.OpenAI.OpenAIResponse{JSON3.Object{Vector{UInt8}, Vector{UInt64}}}(200, {
 ```
 """
 function delete_assistant(api_key::AbstractString,
-    assistant_id::AbstractString;
-    http_kwargs::NamedTuple = NamedTuple())
+        assistant_id::AbstractString;
+        http_kwargs::NamedTuple = NamedTuple())
     # The API endpoint is
     # DELETE https://api.openai.com/v1/assistants/:assistant_id
     # Requires the OpenAI-Beta: assistants=v1 header
@@ -421,8 +421,8 @@ thread_id = create_thread(api_key, [
 ```
 """
 function create_thread(api_key::AbstractString,
-    messages = nothing;
-    http_kwargs::NamedTuple = NamedTuple())
+        messages = nothing;
+        http_kwargs::NamedTuple = NamedTuple())
     # The API endpoint is
     # POST https://api.openai.com/v1/threads
     # Requires the OpenAI-Beta: assistants=v1 header
@@ -444,8 +444,8 @@ thread = retrieve_thread(api_key, thread_id)
 ```
 """
 function retrieve_thread(api_key::AbstractString,
-    thread_id::AbstractString;
-    http_kwargs::NamedTuple = NamedTuple())
+        thread_id::AbstractString;
+        http_kwargs::NamedTuple = NamedTuple())
     # The API endpoint is
     # GET https://api.openai.com/v1/threads/:thread_id
     # Requires the OpenAI-Beta: assistants=v1 header
@@ -466,8 +466,8 @@ delete_thread(api_key, thread_id)
 ```
 """
 function delete_thread(api_key::AbstractString,
-    thread_id::AbstractString;
-    http_kwargs::NamedTuple = NamedTuple())
+        thread_id::AbstractString;
+        http_kwargs::NamedTuple = NamedTuple())
     # The API endpoint is
     # DELETE https://api.openai.com/v1/threads/:thread_id
     # Requires the OpenAI-Beta: assistants=v1 header
@@ -492,9 +492,9 @@ modify_thread(api_key, thread_id, metadata=Dict("key" => "value"))
 ```
 """
 function modify_thread(api_key::AbstractString,
-    thread_id::AbstractString;
-    metadata = nothing,
-    http_kwargs::NamedTuple = NamedTuple())
+        thread_id::AbstractString;
+        metadata = nothing,
+        http_kwargs::NamedTuple = NamedTuple())
     # The API endpoint is
     # PATCH https://api.openai.com/v1/threads/:thread_id
     # Requires the OpenAI-Beta: assistants=v1 header
@@ -515,12 +515,12 @@ end
 
 """
 function create_message(api_key::AbstractString,
-    thread_id::AbstractString,
-    # role::AbstractString, # Currently role is always "user"
-    content::AbstractString;
-    file_ids = nothing,
-    metadata = nothing,
-    http_kwargs::NamedTuple = NamedTuple())
+        thread_id::AbstractString,
+        # role::AbstractString, # Currently role is always "user"
+        content::AbstractString;
+        file_ids = nothing,
+        metadata = nothing,
+        http_kwargs::NamedTuple = NamedTuple())
     # The API endpoint is
     # POST https://api.openai.com/v1/threads/:thread_id/messages
     # Requires the OpenAI-Beta: assistants=v1 header
@@ -554,9 +554,9 @@ end
 Retrieves a message by ID.
 """
 function retrieve_message(api_key::AbstractString,
-    thread_id::AbstractString,
-    message_id::AbstractString;
-    http_kwargs::NamedTuple = NamedTuple())
+        thread_id::AbstractString,
+        message_id::AbstractString;
+        http_kwargs::NamedTuple = NamedTuple())
     # The API endpoint is
     # GET https://api.openai.com/v1/threads/:thread_id/messages/:message_id
     # Requires the OpenAI-Beta: assistants=v1 header
@@ -572,9 +572,9 @@ end
     
 """
 function delete_message(api_key::AbstractString,
-    thread_id::AbstractString,
-    message_id::AbstractString;
-    http_kwargs::NamedTuple = NamedTuple())
+        thread_id::AbstractString,
+        message_id::AbstractString;
+        http_kwargs::NamedTuple = NamedTuple())
     # The API endpoint is
     # DELETE https://api.openai.com/v1/threads/:thread_id/messages/:message_id
     # Requires the OpenAI-Beta: assistants=v1 header
@@ -590,10 +590,10 @@ end
 
 """
 function modify_message(api_key::AbstractString,
-    thread_id::AbstractString,
-    message_id::AbstractString;
-    metadata = nothing,
-    http_kwargs::NamedTuple = NamedTuple())
+        thread_id::AbstractString,
+        message_id::AbstractString;
+        metadata = nothing,
+        http_kwargs::NamedTuple = NamedTuple())
     # The API endpoint is
     # PATCH https://api.openai.com/v1/threads/:thread_id/messages/:message_id
     # Requires the OpenAI-Beta: assistants=v1 header
@@ -612,19 +612,19 @@ Returns an `OpenAIResponse` object containing a list of messages,
 sorted by the `created_at` timestamp of the objects.
 """
 function list_messages(api_key::AbstractString,
-    thread_id::AbstractString;
-    limit::Union{Integer, AbstractString} = 20,
-    order::AbstractString = "desc",
-    after::AbstractString = "",
-    before::AbstractString = "",
-    http_kwargs::NamedTuple = NamedTuple())
+        thread_id::AbstractString;
+        limit::Union{Integer, AbstractString} = 20,
+        order::AbstractString = "desc",
+        after::AbstractString = "",
+        before::AbstractString = "",
+        http_kwargs::NamedTuple = NamedTuple())
     # The API endpoint is
     # GET https://api.openai.com/v1/threads/:thread_id/messages
     # Requires the OpenAI-Beta: assistants=v1 header
 
     # Build query parameters
     query = Pair{String, String}["limit" => string(limit),
-        "order" => order]
+    "order" => order]
     length(after) > 0 && push!(query, "after" => after)
     length(before) > 0 && push!(query, "before" => before)
 
@@ -647,13 +647,13 @@ end
 POST https://api.openai.com/v1/threads/{thread_id}/runs
 """
 function create_run(api_key::AbstractString,
-    thread_id::AbstractString,
-    assistant_id::AbstractString,
-    instructions = nothing;
-    tools = nothing,
-    metadata = nothing,
-    model = nothing,
-    http_kwargs::NamedTuple = NamedTuple())
+        thread_id::AbstractString,
+        assistant_id::AbstractString,
+        instructions = nothing;
+        tools = nothing,
+        metadata = nothing,
+        model = nothing,
+        http_kwargs::NamedTuple = NamedTuple())
     # The API endpoint is
     # POST https://api.openai.com/v1/threads/:thread_id/runs
     # Requires the OpenAI-Beta: assistants=v1 header
@@ -675,9 +675,9 @@ end
 GET https://api.openai.com/v1/threads/{thread_id}/runs/{run_id}
 """
 function retrieve_run(api_key::AbstractString,
-    thread_id::AbstractString,
-    run_id::AbstractString;
-    http_kwargs::NamedTuple = NamedTuple())
+        thread_id::AbstractString,
+        run_id::AbstractString;
+        http_kwargs::NamedTuple = NamedTuple())
     # The API endpoint is
     # GET https://api.openai.com/v1/threads/:thread_id/runs/:run_id
     # Requires the OpenAI-Beta: assistants=v1 header
@@ -694,10 +694,10 @@ end
 POST https://api.openai.com/v1/threads/{thread_id}/runs/{run_id}
 """
 function modify_run(api_key::AbstractString,
-    thread_id::AbstractString,
-    run_id::AbstractString;
-    metadata = nothing,
-    http_kwargs::NamedTuple = NamedTuple())
+        thread_id::AbstractString,
+        run_id::AbstractString;
+        metadata = nothing,
+        http_kwargs::NamedTuple = NamedTuple())
     # The API endpoint is
     # POST https://api.openai.com/v1/threads/:thread_id/runs/:run_id
     # Requires the OpenAI-Beta: assistants=v1 header
@@ -715,19 +715,19 @@ end
 GET https://api.openai.com/v1/threads/{thread_id}/runs
 """
 function list_runs(api_key::AbstractString,
-    thread_id::AbstractString;
-    limit::Union{Integer, AbstractString} = 20,
-    order::AbstractString = "desc",
-    after::AbstractString = "",
-    before::AbstractString = "",
-    http_kwargs::NamedTuple = NamedTuple())
+        thread_id::AbstractString;
+        limit::Union{Integer, AbstractString} = 20,
+        order::AbstractString = "desc",
+        after::AbstractString = "",
+        before::AbstractString = "",
+        http_kwargs::NamedTuple = NamedTuple())
     # The API endpoint is
     # GET https://api.openai.com/v1/threads/:thread_id/runs
     # Requires the OpenAI-Beta: assistants=v1 header
 
     # Build query parameters
     query = Pair{String, String}["limit" => string(limit),
-        "order" => order]
+    "order" => order]
     length(after) > 0 && push!(query, "after" => after)
     length(before) > 0 && push!(query, "before" => before)
 
@@ -746,9 +746,9 @@ end
 POST https://api.openai.com/v1/threads/{thread_id}/runs/{run_id}/cancel
 """
 function cancel_run(api_key::AbstractString,
-    thread_id::AbstractString,
-    run_id::AbstractString;
-    http_kwargs::NamedTuple = NamedTuple())
+        thread_id::AbstractString,
+        run_id::AbstractString;
+        http_kwargs::NamedTuple = NamedTuple())
     # The API endpoint is
     # POST https://api.openai.com/v1/threads/:thread_id/runs/:run_id/cancel
     # Requires the OpenAI-Beta: assistants=v1 header
@@ -781,13 +781,13 @@ POST https://api.openai.com/v1/threads/runs
 - `metadata` is a `Dict` representing the metadata for the run.
 """
 function create_thread_and_run(api_key::AbstractString,
-    assistant_id::AbstractString;
-    thread = nothing,
-    model = nothing,
-    instructions = nothing,
-    tools = nothing,
-    metadata = nothing,
-    http_kwargs::NamedTuple = NamedTuple())
+        assistant_id::AbstractString;
+        thread = nothing,
+        model = nothing,
+        instructions = nothing,
+        tools = nothing,
+        metadata = nothing,
+        http_kwargs::NamedTuple = NamedTuple())
     # The API endpoint is
     # POST https://api.openai.com/v1/threads/runs
     # Requires the OpenAI-Beta: assistants=v1 header

--- a/test/assistants.jl
+++ b/test/assistants.jl
@@ -32,7 +32,7 @@
 
 # Set API/model
 api_key = ENV["OPENAI_API_KEY"]
-test_model = "gpt-4o-mini"
+test_model = "gpt-5-mini"
 
 # Test functions for the assistant generation/modification/etc.
 @testset "Assistants" begin
@@ -158,7 +158,7 @@ end
     # Make a thread
     thread = create_thread(api_key,
         [
-            Dict("role" => "user", "content" => "Hello, how are you?"),
+            Dict("role" => "user", "content" => "Hello, how are you?")
         ])
 
     # Make a run

--- a/test/chatcompletion.jl
+++ b/test/chatcompletion.jl
@@ -1,6 +1,6 @@
 @testset "chatcompletion" begin
     r = create_chat(ENV["OPENAI_API_KEY"],
-        "gpt-4o-mini",
+        "gpt-5-mini",
         [Dict("role" => "user", "content" => "What is the OpenAI mission?")])
     println(r.response["choices"][begin]["message"]["content"])
     if !=(r.status, 200)
@@ -9,10 +9,10 @@
 
     # with http kwargs (with default values)
     r = create_chat(ENV["OPENAI_API_KEY"],
-        "gpt-4o-mini",
+        "gpt-5-mini",
         [
             Dict("role" => "user",
-            "content" => "Summarize HTTP.jl package in a short sentence."),
+            "content" => "Summarize HTTP.jl package in a short sentence.")
         ],
         http_kwargs = (connect_timeout = 10, readtimeout = 0))
     println(r.response["choices"][begin]["message"]["content"])
@@ -22,22 +22,16 @@
 end
 
 @testset "chatcompletion - streaming" begin
+    cb = StreamCallback()
     r = create_chat(ENV["OPENAI_API_KEY"],
-        "gpt-4o-mini",
+        "gpt-5-mini",
         [
             Dict("role" => "user",
-            "content" => "What continent is New York in? Two word answer."),
-        ],
-        streamcallback = let
-            count = 0
+            "content" => "What continent is New York in? Two word answer.")
+        ];
+        streamcallback = cb)
 
-            function f(s::String)
-                count = count + 1
-                println("Chunk $count")
-            end
-        end)
-
-    println(map(r -> r["choices"][1]["delta"], r.response))
+    println("Received $(length(cb.chunks)) chunks")
     if !=(r.status, 200)
         @test false
     end

--- a/test/chatcompletion.jl
+++ b/test/chatcompletion.jl
@@ -12,7 +12,7 @@
         "gpt-4o-mini",
         [
             Dict("role" => "user",
-                "content" => "Summarize HTTP.jl package in a short sentence."),
+            "content" => "Summarize HTTP.jl package in a short sentence."),
         ],
         http_kwargs = (connect_timeout = 10, readtimeout = 0))
     println(r.response["choices"][begin]["message"]["content"])
@@ -26,7 +26,7 @@ end
         "gpt-4o-mini",
         [
             Dict("role" => "user",
-                "content" => "What continent is New York in? Two word answer."),
+            "content" => "What continent is New York in? Two word answer."),
         ],
         streamcallback = let
             count = 0

--- a/test/chatcompletion.jl
+++ b/test/chatcompletion.jl
@@ -24,7 +24,7 @@ end
 @testset "chatcompletion - streaming" begin
     cb = StreamCallback()
     r = create_chat(ENV["OPENAI_API_KEY"],
-        "gpt-5-mini",
+        "gpt-4o-mini",
         [
             Dict("role" => "user",
             "content" => "What continent is New York in? Two word answer.")

--- a/test/responses.jl
+++ b/test/responses.jl
@@ -1,23 +1,28 @@
 
-@testset "Responses" begin 
+@testset "Responses" begin
     ## Image response tag 
-    input = [Dict("role" => "user", 
-    "content" => [Dict("type" => "input_text", "text" => "What is in this image?"), 
-                 Dict("type" => "input_image", "image_url" => "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg")])
-            ]
+    input = [Dict("role" => "user",
+        "content" => [Dict("type" => "input_text", "text" => "What is in this image?"),
+            Dict("type" => "input_image",
+                "image_url" => "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg")])
+    ]
     resp = create_responses(ENV["OPENAI_API_KEY"], input)
     if !=(resp.status, 200)
         @test false
     end
 
     ## Web search 
-    resp = create_responses(ENV["OPENAI_API_KEY"], "What was a positive news story from today?"; tools=[Dict("type" => "web_search_preview")])
+    resp = create_responses(
+        ENV["OPENAI_API_KEY"], "What was a positive news story from today?";
+        tools = [Dict("type" => "web_search_preview")])
     if !=(resp.status, 200)
         @test false
     end
 
     ## Streaming 
-    resp = create_responses(ENV["OPENAI_API_KEY"], "Hello!"; instructions="You are a helpful assistant.", stream=true, streamcallback = x->println(x))
+    resp = create_responses(
+        ENV["OPENAI_API_KEY"], "Hello!"; instructions = "You are a helpful assistant.",
+        stream = true, streamcallback = x->println(x))
     if !=(resp.status, 200)
         @test false
     end
@@ -25,35 +30,35 @@
     ## Functions 
     tools = [
         Dict(
-            "type" => "function",
-            "name" => "get_current_weather",
-            "description" => "Get the current weather in a given location",
-            "parameters" => Dict(
+        "type" => "function",
+        "name" => "get_current_weather",
+        "description" => "Get the current weather in a given location",
+        "parameters" => Dict(
             "type" => "object",
             "properties" => Dict(
                 "location" => Dict(
                     "type" => "string",
-                    "description" => "The city and state, e.g. San Francisco, CA",
+                    "description" => "The city and state, e.g. San Francisco, CA"
                 ),
-                "unit"=> Dict("type" => "string", "enum" => ["celsius", "fahrenheit"]),
+                "unit" => Dict("type" => "string", "enum" => ["celsius", "fahrenheit"])
             ),
-            "required" => ["location", "unit"],
-            )
+            "required" => ["location", "unit"]
         )
+    )
     ]
-    resp = create_responses(ENV["OPENAI_API_KEY"], "What is the weather in Boston?"; tools=tools, tool_choice="auto")
+    resp = create_responses(ENV["OPENAI_API_KEY"], "What is the weather in Boston?";
+        tools = tools, tool_choice = "auto")
     if !=(resp.status, 200)
         @test false
     end
 
     ## Reasoning 
 
-    resp = create_responses(ENV["OPENAI_API_KEY"], "How much wood would a woodchuck chuck?";
-    model = "o3-mini",
-    reasoning=Dict("effort" => "high"))
+    resp = create_responses(
+        ENV["OPENAI_API_KEY"], "How much wood would a woodchuck chuck?";
+        model = "o3-mini",
+        reasoning = Dict("effort" => "high"))
     if !=(resp.status, 200)
         @test false
     end
-
-
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,23 +21,19 @@ end
 
 @testset "OpenAI.jl" begin
     printstyled(color = :blue, "\n")
-    if haskey(ENV, "OPENAI_API_KEY") && get(ENV, "OPENAI_RUN_LIVE_TESTS", "") == "true"
-        # Disable SSL verification in CI environments that inject self-signed certificates
-        ENV["JULIA_SSL_NO_VERIFY_HOSTS"] = "*"
-        @testset "models" begin
-            include("models.jl")
-        end
-        @testset "chatcompletion" begin
-            include("chatcompletion.jl")
-        end
-        @testset "completion" begin
-            include("completion.jl")
-        end
-        @testset "embeddings" begin
-            include("embeddings.jl")
-        end
-    else
-        @info "Skipping live API tests"
+    # Disable SSL verification in CI environments that inject self-signed certificates
+    ENV["JULIA_SSL_NO_VERIFY_HOSTS"] = "*"
+    @testset "models" begin
+        include("models.jl")
+    end
+    @testset "chatcompletion" begin
+        include("chatcompletion.jl")
+    end
+    @testset "completion" begin
+        include("completion.jl")
+    end
+    @testset "embeddings" begin
+        include("embeddings.jl")
     end
     @testset "streamcallbacks" begin
         include("streamcallbacks.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,17 +21,24 @@ end
 
 @testset "OpenAI.jl" begin
     printstyled(color = :blue, "\n")
-    @testset "models" begin
-        include("models.jl")
+    if haskey(ENV, "OPENAI_API_KEY")
+        @testset "models" begin
+            include("models.jl")
+        end
+        @testset "chatcompletion" begin
+            include("chatcompletion.jl")
+        end
+        @testset "completion" begin
+            include("completion.jl")
+        end
+        @testset "embeddings" begin
+            include("embeddings.jl")
+        end
+    else
+        @info "OPENAI_API_KEY not set; skipping live API tests"
     end
-    @testset "chatcompletion" begin
-        include("chatcompletion.jl")
-    end
-    @testset "completion" begin
-        include("completion.jl")
-    end
-    @testset "embeddings" begin
-        include("embeddings.jl")
+    @testset "streamcallbacks" begin
+        include("streamcallbacks.jl")
     end
     # @testset "assistants" begin
     #     include("assistants.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,9 @@ end
 
 @testset "OpenAI.jl" begin
     printstyled(color = :blue, "\n")
-    if haskey(ENV, "OPENAI_API_KEY")
+    if haskey(ENV, "OPENAI_API_KEY") && get(ENV, "OPENAI_RUN_LIVE_TESTS", "") == "true"
+        # Disable SSL verification in CI environments that inject self-signed certificates
+        ENV["JULIA_SSL_NO_VERIFY_HOSTS"] = "*"
         @testset "models" begin
             include("models.jl")
         end
@@ -35,7 +37,7 @@ end
             include("embeddings.jl")
         end
     else
-        @info "OPENAI_API_KEY not set; skipping live API tests"
+        @info "Skipping live API tests"
     end
     @testset "streamcallbacks" begin
         include("streamcallbacks.jl")

--- a/test/streamcallbacks.jl
+++ b/test/streamcallbacks.jl
@@ -1,0 +1,27 @@
+using Test
+using HTTP
+using Sockets
+using OpenAI
+using StreamCallbacks
+
+@testset "StreamCallbacks integration" begin
+    port = 9178
+    handler(req) = HTTP.Response(200,
+        ["Content-Type" => "text/event-stream"],
+        "data: {\"choices\": [{\"delta\": {\"content\": \"hello\"}}]}\n\n" *
+        "data: [DONE]\n\n")
+    server = HTTP.serve!(handler, Sockets.localhost, port; verbose = false)
+    try
+        io = IOBuffer()
+        provider = OpenAI.OpenAIProvider(base_url = "http://127.0.0.1:$port")
+        resp = OpenAI.create_chat(nothing, "key", "model",
+            [Dict("role" => "user", "content" => "hi")];
+            provider = provider,
+            streamcallback = io)
+        seekstart(io)
+        @test occursin("hello", String(take!(io)))
+        @test resp.status == 200
+    finally
+        HTTP.forceclose(server)
+    end
+end

--- a/test/streamcallbacks.jl
+++ b/test/streamcallbacks.jl
@@ -2,7 +2,6 @@ using Test
 using HTTP
 using Sockets
 using OpenAI
-using StreamCallbacks
 
 @testset "StreamCallbacks integration" begin
     port = 9178
@@ -12,15 +11,24 @@ using StreamCallbacks
         "data: [DONE]\n\n")
     server = HTTP.serve!(handler, Sockets.localhost, port; verbose = false)
     try
+        provider = OpenAI.OpenAIProvider(api_key = "key", base_url = "http://127.0.0.1:$port")
+
         io = IOBuffer()
-        provider = OpenAI.OpenAIProvider(base_url = "http://127.0.0.1:$port")
-        resp = OpenAI.create_chat(nothing, "key", "model",
+        resp = OpenAI.create_chat(provider, "model",
             [Dict("role" => "user", "content" => "hi")];
-            provider = provider,
             streamcallback = io)
         seekstart(io)
         @test occursin("hello", String(take!(io)))
         @test resp.status == 200
+
+        buf = IOBuffer()
+        cbfunc = text -> write(buf, text)
+        resp2 = OpenAI.create_chat(provider, "model",
+            [Dict("role" => "user", "content" => "hi")];
+            streamcallback = cbfunc)
+        seekstart(buf)
+        @test occursin("hello", String(take!(buf)))
+        @test resp2.status == 200
     finally
         HTTP.forceclose(server)
     end


### PR DESCRIPTION
Closes https://github.com/JuliaML/OpenAI.jl/issues/65

This PR:
- adds StreamCallbacks.jl dependency, replacing the existing streaming implementation
- implements `configure_callback!` helper and extend `create_chat` to support custom providers and StreamCallbacks
- Adds the explanation to docs, README and a dedicated example to showcase different streaming use cases

Other minor things:
- replaced model to gpt-5-mini to be more current
- re-formatted with the latest JuliaFormatter, CI was failing otherwise(that's why most files seem "changed")

Tests pass and examples execute as expected.